### PR TITLE
feat: Add more array types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ The official Go driver for Postgres doesn't support slices of all types availabl
 ## pqextended.Array
 `pqextended.Array` is a drop-in replacement for `pq.Array`. If a type is unknown, `pq.Array` is called internally. Currently supports:
 
+- `[]int8`
+- `[]int16`
 - `[]uint8`
+- `[]uint16`
+- `[]uint32`
+- `[]uint64`
 
 ```go
 postgres, err := sql.Open("postgres", os.Getenv("POSTGRES_URI"))

--- a/array.go
+++ b/array.go
@@ -7,15 +7,40 @@ import (
 	"github.com/lib/pq"
 )
 
+// Array returns the optimal driver.Valuer and sql.Scanner for an array or
+// slice of any dimension.
+//
+// Wraps around pq.Array, but adds support for more array types.
 func Array(a interface{}) interface {
 	driver.Valuer
 	sql.Scanner
 } {
 	switch a := a.(type) {
+	case []int8:
+		return (*Int8Array)(&a)
+	case *[]int8:
+		return (*Int8Array)(a)
+	case []int16:
+		return (*Int16Array)(&a)
+	case *[]int16:
+		return (*Int16Array)(a)
+
 	case []uint8:
 		return (*UInt8Array)(&a)
 	case *[]uint8:
 		return (*UInt8Array)(a)
+	case []uint16:
+		return (*UInt16Array)(&a)
+	case *[]uint16:
+		return (*UInt16Array)(a)
+	case []uint32:
+		return (*UInt32Array)(&a)
+	case *[]uint32:
+		return (*UInt32Array)(a)
+	case []uint64:
+		return (*UInt64Array)(&a)
+	case *[]uint64:
+		return (*UInt64Array)(a)
 	}
 
 	return pq.Array(a)

--- a/array.go
+++ b/array.go
@@ -24,7 +24,6 @@ func Array(a interface{}) interface {
 		return (*Int16Array)(&a)
 	case *[]int16:
 		return (*Int16Array)(a)
-
 	case []uint8:
 		return (*UInt8Array)(&a)
 	case *[]uint8:

--- a/int16_array.go
+++ b/int16_array.go
@@ -1,0 +1,76 @@
+package pqextended
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Int16Array implements the pq Scan and Value interface for int16 slice type
+type Int16Array []int16
+
+// Scan implements the sql.Scanner interface
+func (a *Int16Array) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("PQ Extended: Cannot convert %T to Int8Array", src)
+}
+
+func (a *Int16Array) scanBytes(src []byte) error {
+	str := string(src)
+	str = strings.TrimSuffix(str, "}")
+	str = strings.TrimPrefix(str, "{")
+	strSlice := strings.Split(str, ",")
+
+	b := make([]int16, 0, len(strSlice))
+
+	for i := 0; i < len(strSlice); i++ {
+		number, err := strconv.Atoi(strSlice[i])
+
+		if err != nil {
+			return err
+		}
+
+		b = append(b, int16(number))
+	}
+
+	*a = b
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (a Int16Array) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		var b strings.Builder
+
+		b.WriteString("{")
+
+		for i := 0; i < n; i++ {
+			if i != n-1 {
+				b.WriteString(fmt.Sprintf("%d,", a[i]))
+			} else {
+				b.WriteString(fmt.Sprintf("%d", a[i]))
+			}
+		}
+
+		b.WriteString("}")
+
+		return b.String(), nil
+	}
+
+	return "{}", nil
+}

--- a/int16_array_test.go
+++ b/int16_array_test.go
@@ -1,0 +1,49 @@
+package pqextended
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestInt16Array(t *testing.T) {
+	godotenv.Load()
+
+	postgres, err := sql.Open("postgres", os.Getenv("PQ_EXTENDED_TEST_POSTGRES_URI"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS int16_slices (
+		id integer,
+		int16_slice smallint[]
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []int16{0, -1, 32767, -32768}
+
+	_, err = postgres.Exec(`INSERT INTO int16_slices (id, int16_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 1, Array(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int16
+
+	err = postgres.QueryRow(`SELECT int16_slice FROM int16_slices WHERE id=$1`, 1).Scan(Array(&output))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(input, output) {
+		t.Fatalf("Input and output did not match. Expected %v, got %v.", input, output)
+	}
+
+	fmt.Printf("Input []int16: %v\n", input)
+	fmt.Printf("Output []int16: %v\n", output)
+}

--- a/int8_array.go
+++ b/int8_array.go
@@ -1,0 +1,76 @@
+package pqextended
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Int8Array implements the pq Scan and Value interface for int8 slice type
+type Int8Array []int8
+
+// Scan implements the sql.Scanner interface
+func (a *Int8Array) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("PQ Extended: Cannot convert %T to Int8Array", src)
+}
+
+func (a *Int8Array) scanBytes(src []byte) error {
+	str := string(src)
+	str = strings.TrimSuffix(str, "}")
+	str = strings.TrimPrefix(str, "{")
+	strSlice := strings.Split(str, ",")
+
+	b := make([]int8, 0, len(strSlice))
+
+	for i := 0; i < len(strSlice); i++ {
+		number, err := strconv.Atoi(strSlice[i])
+
+		if err != nil {
+			return err
+		}
+
+		b = append(b, int8(number))
+	}
+
+	*a = b
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (a Int8Array) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		var b strings.Builder
+
+		b.WriteString("{")
+
+		for i := 0; i < n; i++ {
+			if i != n-1 {
+				b.WriteString(fmt.Sprintf("%d,", a[i]))
+			} else {
+				b.WriteString(fmt.Sprintf("%d", a[i]))
+			}
+		}
+
+		b.WriteString("}")
+
+		return b.String(), nil
+	}
+
+	return "{}", nil
+}

--- a/int8_array_test.go
+++ b/int8_array_test.go
@@ -1,0 +1,49 @@
+package pqextended
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestInt8Array(t *testing.T) {
+	godotenv.Load()
+
+	postgres, err := sql.Open("postgres", os.Getenv("PQ_EXTENDED_TEST_POSTGRES_URI"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS int8_slices (
+		id integer,
+		int8_slice smallint[]
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []int8{0, -1, 127, -128}
+
+	_, err = postgres.Exec(`INSERT INTO int8_slices (id, int8_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 1, Array(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int8
+
+	err = postgres.QueryRow(`SELECT int8_slice FROM int8_slices WHERE id=$1`, 1).Scan(Array(&output))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(input, output) {
+		t.Fatalf("Input and output did not match. Expected %v, got %v.", input, output)
+	}
+
+	fmt.Printf("Input []int8: %v\n", input)
+	fmt.Printf("Output []int8: %v\n", output)
+}

--- a/uint16_array.go
+++ b/uint16_array.go
@@ -1,0 +1,76 @@
+package pqextended
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// UInt16Array implements the pq Scan and Value interface for uint16 slice type
+type UInt16Array []uint16
+
+// Scan implements the sql.Scanner interface
+func (a *UInt16Array) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("PQ Extended: Cannot convert %T to UInt8Array", src)
+}
+
+func (a *UInt16Array) scanBytes(src []byte) error {
+	str := string(src)
+	str = strings.TrimSuffix(str, "}")
+	str = strings.TrimPrefix(str, "{")
+	strSlice := strings.Split(str, ",")
+
+	b := make([]uint16, 0, len(strSlice))
+
+	for i := 0; i < len(strSlice); i++ {
+		number, err := strconv.Atoi(strSlice[i])
+
+		if err != nil {
+			return err
+		}
+
+		b = append(b, uint16(number))
+	}
+
+	*a = b
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (a UInt16Array) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		var b strings.Builder
+
+		b.WriteString("{")
+
+		for i := 0; i < n; i++ {
+			if i != n-1 {
+				b.WriteString(fmt.Sprintf("%d,", a[i]))
+			} else {
+				b.WriteString(fmt.Sprintf("%d", a[i]))
+			}
+		}
+
+		b.WriteString("}")
+
+		return b.String(), nil
+	}
+
+	return "{}", nil
+}

--- a/uint16_array_test.go
+++ b/uint16_array_test.go
@@ -1,0 +1,49 @@
+package pqextended
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestUInt16Array(t *testing.T) {
+	godotenv.Load()
+
+	postgres, err := sql.Open("postgres", os.Getenv("PQ_EXTENDED_TEST_POSTGRES_URI"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS uint16_slices (
+		id integer,
+		uint16_slice integer[]
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []uint16{0, 1, 2, 65535}
+
+	_, err = postgres.Exec(`INSERT INTO uint16_slices (id, uint16_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 1, Array(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []uint16
+
+	err = postgres.QueryRow(`SELECT uint16_slice FROM uint16_slices WHERE id=$1`, 1).Scan(Array(&output))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(input, output) {
+		t.Fatalf("Input and output did not match. Expected %v, got %v.", input, output)
+	}
+
+	fmt.Printf("Input []uint16: %v\n", input)
+	fmt.Printf("Output []uint16: %v\n", output)
+}

--- a/uint32_array.go
+++ b/uint32_array.go
@@ -1,0 +1,76 @@
+package pqextended
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// UInt32Array implements the pq Scan and Value interface for uint32 slice type
+type UInt32Array []uint32
+
+// Scan implements the sql.Scanner interface
+func (a *UInt32Array) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("PQ Extended: Cannot convert %T to UInt8Array", src)
+}
+
+func (a *UInt32Array) scanBytes(src []byte) error {
+	str := string(src)
+	str = strings.TrimSuffix(str, "}")
+	str = strings.TrimPrefix(str, "{")
+	strSlice := strings.Split(str, ",")
+
+	b := make([]uint32, 0, len(strSlice))
+
+	for i := 0; i < len(strSlice); i++ {
+		number, err := strconv.ParseUint(strSlice[i], 10, 32)
+
+		if err != nil {
+			return err
+		}
+
+		b = append(b, uint32(number))
+	}
+
+	*a = b
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (a UInt32Array) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		var b strings.Builder
+
+		b.WriteString("{")
+
+		for i := 0; i < n; i++ {
+			if i != n-1 {
+				b.WriteString(fmt.Sprintf("%d,", a[i]))
+			} else {
+				b.WriteString(fmt.Sprintf("%d", a[i]))
+			}
+		}
+
+		b.WriteString("}")
+
+		return b.String(), nil
+	}
+
+	return "{}", nil
+}

--- a/uint32_array_test.go
+++ b/uint32_array_test.go
@@ -1,0 +1,49 @@
+package pqextended
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestUInt32Array(t *testing.T) {
+	godotenv.Load()
+
+	postgres, err := sql.Open("postgres", os.Getenv("PQ_EXTENDED_TEST_POSTGRES_URI"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS uint32_slices (
+		id integer,
+		uint32_slice bigint[]
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []uint32{0, 1, 2, 4294967295}
+
+	_, err = postgres.Exec(`INSERT INTO uint32_slices (id, uint32_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 1, Array(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []uint32
+
+	err = postgres.QueryRow(`SELECT uint32_slice FROM uint32_slices WHERE id=$1`, 1).Scan(Array(&output))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(input, output) {
+		t.Fatalf("Input and output did not match. Expected %v, got %v.", input, output)
+	}
+
+	fmt.Printf("Input []uint32: %v\n", input)
+	fmt.Printf("Output []uint32: %v\n", output)
+}

--- a/uint64_array.go
+++ b/uint64_array.go
@@ -1,0 +1,76 @@
+package pqextended
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// UInt64Array implements the pq Scan and Value interface for uint64 slice type
+type UInt64Array []uint64
+
+// Scan implements the sql.Scanner interface
+func (a *UInt64Array) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("PQ Extended: Cannot convert %T to UInt8Array", src)
+}
+
+func (a *UInt64Array) scanBytes(src []byte) error {
+	str := string(src)
+	str = strings.TrimSuffix(str, "}")
+	str = strings.TrimPrefix(str, "{")
+	strSlice := strings.Split(str, ",")
+
+	b := make([]uint64, 0, len(strSlice))
+
+	for i := 0; i < len(strSlice); i++ {
+		number, err := strconv.ParseUint(strSlice[i], 10, 64)
+
+		if err != nil {
+			return err
+		}
+
+		b = append(b, number)
+	}
+
+	*a = b
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (a UInt64Array) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		var b strings.Builder
+
+		b.WriteString("{")
+
+		for i := 0; i < n; i++ {
+			if i != n-1 {
+				b.WriteString(fmt.Sprintf("%d,", a[i]))
+			} else {
+				b.WriteString(fmt.Sprintf("%d", a[i]))
+			}
+		}
+
+		b.WriteString("}")
+
+		return b.String(), nil
+	}
+
+	return "{}", nil
+}

--- a/uint64_array_test.go
+++ b/uint64_array_test.go
@@ -1,0 +1,49 @@
+package pqextended
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestUInt64Array(t *testing.T) {
+	godotenv.Load()
+
+	postgres, err := sql.Open("postgres", os.Getenv("PQ_EXTENDED_TEST_POSTGRES_URI"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS uint64_slices (
+		id integer,
+		uint64_slice bigint[]
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []uint64{0, 1, 2, 4294967295} // Postgres doesn't have a bigger type to support the whole uint64 range
+
+	_, err = postgres.Exec(`INSERT INTO uint64_slices (id, uint64_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 1, Array(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []uint64
+
+	err = postgres.QueryRow(`SELECT uint64_slice FROM uint64_slices WHERE id=$1`, 1).Scan(Array(&output))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(input, output) {
+		t.Fatalf("Input and output did not match. Expected %v, got %v.", input, output)
+	}
+
+	fmt.Printf("Input []uint64: %v\n", input)
+	fmt.Printf("Output []uint64: %v\n", output)
+}

--- a/uint64_array_test.go
+++ b/uint64_array_test.go
@@ -20,13 +20,13 @@ func TestUInt64Array(t *testing.T) {
 
 	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS uint64_slices (
 		id integer,
-		uint64_slice bigint[]
+		uint64_slice numeric(20)[]
 	)`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	input := []uint64{0, 1, 2, 4294967295} // Postgres doesn't have a bigger type to support the whole uint64 range
+	input := []uint64{0, 1, 2, 18446744073709551615}
 
 	_, err = postgres.Exec(`INSERT INTO uint64_slices (id, uint64_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 1, Array(input))
 	if err != nil {

--- a/uint8_array_test.go
+++ b/uint8_array_test.go
@@ -20,13 +20,13 @@ func TestUInt8Array(t *testing.T) {
 
 	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS uint8_slices (
 		id integer,
-		uint8_slice integer[]
+		uint8_slice smallint[]
 	)`)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	input := []uint8{0, 1, 2, 3}
+	input := []uint8{0, 1, 2, 255}
 
 	_, err = postgres.Exec(`INSERT INTO uint8_slices (id, uint8_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 1, Array(input))
 	if err != nil {
@@ -44,6 +44,6 @@ func TestUInt8Array(t *testing.T) {
 		t.Fatalf("Input and output did not match. Expected %v, got %v.", input, output)
 	}
 
-	fmt.Printf("Input: %v\n", input)
-	fmt.Printf("Output: %v\n", output)
+	fmt.Printf("Input []uint8: %v\n", input)
+	fmt.Printf("Output []uint8: %v\n", output)
 }


### PR DESCRIPTION
This PR adds the following array types to `pqextended.Array`:
- `[]int8`
- `[]int16`
- `[]uint16`
- `[]uint32`
- `[]uint64`