### PR TITLE
fix: Support scanning empty arrays

### DIFF
--- a/int16_array.go
+++ b/int16_array.go
@@ -29,6 +29,12 @@ func (a *Int16Array) scanBytes(src []byte) error {
 	str := string(src)
 	str = strings.TrimSuffix(str, "}")
 	str = strings.TrimPrefix(str, "{")
+
+	if str == "" {
+		*a = make([]int16, 0)
+		return nil
+	}
+
 	strSlice := strings.Split(str, ",")
 
 	b := make([]int16, 0, len(strSlice))

--- a/int8_array.go
+++ b/int8_array.go
@@ -29,6 +29,12 @@ func (a *Int8Array) scanBytes(src []byte) error {
 	str := string(src)
 	str = strings.TrimSuffix(str, "}")
 	str = strings.TrimPrefix(str, "{")
+
+	if str == "" {
+		*a = make([]int8, 0)
+		return nil
+	}
+
 	strSlice := strings.Split(str, ",")
 
 	b := make([]int8, 0, len(strSlice))

--- a/uint16_array.go
+++ b/uint16_array.go
@@ -29,6 +29,12 @@ func (a *UInt16Array) scanBytes(src []byte) error {
 	str := string(src)
 	str = strings.TrimSuffix(str, "}")
 	str = strings.TrimPrefix(str, "{")
+
+	if str == "" {
+		*a = make([]uint16, 0)
+		return nil
+	}
+
 	strSlice := strings.Split(str, ",")
 
 	b := make([]uint16, 0, len(strSlice))

--- a/uint32_array.go
+++ b/uint32_array.go
@@ -29,6 +29,12 @@ func (a *UInt32Array) scanBytes(src []byte) error {
 	str := string(src)
 	str = strings.TrimSuffix(str, "}")
 	str = strings.TrimPrefix(str, "{")
+
+	if str == "" {
+		*a = make([]uint32, 0)
+		return nil
+	}
+
 	strSlice := strings.Split(str, ",")
 
 	b := make([]uint32, 0, len(strSlice))

--- a/uint64_array.go
+++ b/uint64_array.go
@@ -29,6 +29,12 @@ func (a *UInt64Array) scanBytes(src []byte) error {
 	str := string(src)
 	str = strings.TrimSuffix(str, "}")
 	str = strings.TrimPrefix(str, "{")
+
+	if str == "" {
+		*a = make([]uint64, 0)
+		return nil
+	}
+
 	strSlice := strings.Split(str, ",")
 
 	b := make([]uint64, 0, len(strSlice))

--- a/uint8_array.go
+++ b/uint8_array.go
@@ -29,6 +29,12 @@ func (a *UInt8Array) scanBytes(src []byte) error {
 	str := string(src)
 	str = strings.TrimSuffix(str, "}")
 	str = strings.TrimPrefix(str, "{")
+
+	if str == "" {
+		*a = make([]uint8, 0)
+		return nil
+	}
+
 	strSlice := strings.Split(str, ",")
 
 	b := make([]uint8, 0, len(strSlice))

--- a/uint8_array_test.go
+++ b/uint8_array_test.go
@@ -47,3 +47,41 @@ func TestUInt8Array(t *testing.T) {
 	fmt.Printf("Input []uint8: %v\n", input)
 	fmt.Printf("Output []uint8: %v\n", output)
 }
+
+func TestEmptyArray(t *testing.T) {
+	godotenv.Load()
+
+	postgres, err := sql.Open("postgres", os.Getenv("PQ_EXTENDED_TEST_POSTGRES_URI"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = postgres.Exec(`CREATE TABLE IF NOT EXISTS uint8_slices (
+		id integer,
+		uint8_slice smallint[]
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := []uint8{}
+
+	_, err = postgres.Exec(`INSERT INTO uint8_slices (id, uint8_slice) VALUES ($1, $2) ON CONFLICT DO NOTHING`, 2, Array(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []uint8
+
+	err = postgres.QueryRow(`SELECT uint8_slice FROM uint8_slices WHERE id=$1`, 2).Scan(Array(&output))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(input, output) {
+		t.Fatalf("Input and output did not match. Expected %v, got %v.", input, output)
+	}
+
+	fmt.Printf("Input []uint8: %v\n", input)
+	fmt.Printf("Output []uint8: %v\n", output)
+}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #2 

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

strings.Split returns an array with the initial string if the separator cannot be found. This means that if the array on the database is empty `{}`, this will try to convert an empty string to a number.

Avoid this by checking if the scanned string is empty after removing the brackets, and setting an empty array in that case.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.